### PR TITLE
hide host node_modules folder at docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules


### PR DESCRIPTION
I got `exec format error` from npm after running the container on my Raspi4 for a while. This attempt to fix this error by forcing the Raspberry to build the dependencies from scratch on `docker compose build`.